### PR TITLE
docs: prioritize hosted MCP endpoints in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,93 +24,24 @@ Generate AI videos directly from Claude, VS Code, or any MCP-compatible client.
 
 ## Quick Start
 
-### 1. Get API Token
+### 1. Get Your API Token
 
-Get your API token from [AceDataCloud Platform](https://platform.acedata.cloud):
+1. Sign up at [AceDataCloud Platform](https://platform.acedata.cloud)
+2. Go to the [API documentation page](https://platform.acedata.cloud/documents/5bd3597d-1ff8-44ad-a580-b66b48393e7f)
+3. Click **"Acquire"** to get your API token
+4. Copy the token for use below
 
-1. Sign up or log in
-2. Navigate to [Luma Videos API](https://platform.acedata.cloud/documents/5bd3597d-1ff8-44ad-a580-b66b48393e7f)
-3. Click "Acquire" to get your token
+### 2. Use the Hosted Server (Recommended)
 
-### 2. Install
+AceDataCloud hosts a managed MCP server — **no local installation required**.
 
-```bash
-# Clone the repository
-git clone https://github.com/AceDataCloud/mcp-luma.git
-cd mcp-luma
+**Endpoint:** `https://luma.mcp.acedata.cloud/mcp`
 
-# Install with pip
-pip install -e .
+All requests require a Bearer token. Use the API token from Step 1.
 
-# Or with uv (recommended)
-uv pip install -e .
-```
+#### Claude Desktop
 
-### 3. Configure
-
-```bash
-# Copy example environment file
-cp .env.example .env
-
-# Edit with your API token
-echo "ACEDATACLOUD_API_TOKEN=your_token_here" > .env
-```
-
-### 4. Run
-
-```bash
-# Run the server
-mcp-luma
-
-# Or with Python directly
-python main.py
-```
-
-## Claude Desktop Integration
-
-Add to your Claude Desktop configuration:
-
-**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "luma": {
-      "command": "mcp-luma",
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your_api_token_here"
-      }
-    }
-  }
-}
-```
-
-Or if using uv:
-
-```json
-{
-  "mcpServers": {
-    "luma": {
-      "command": "uv",
-      "args": ["run", "--directory", "/path/to/mcp-luma", "mcp-luma"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your_api_token_here"
-      }
-    }
-  }
-}
-```
-
-## Remote HTTP Mode (Hosted)
-
-AceDataCloud hosts a managed MCP server that you can connect to directly — **no local installation required**.
-
-**Endpoint**: `https://luma.mcp.acedata.cloud/mcp`
-
-All requests require a Bearer token in the `Authorization` header. Get your token from [AceDataCloud Platform](https://platform.acedata.cloud).
-
-### Claude Desktop (Remote)
+Add to your config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
 
 ```json
 {
@@ -119,28 +50,56 @@ All requests require a Bearer token in the `Authorization` header. Get your toke
       "type": "streamable-http",
       "url": "https://luma.mcp.acedata.cloud/mcp",
       "headers": {
-        "Authorization": "Bearer your_api_token_here"
+        "Authorization": "Bearer YOUR_API_TOKEN"
       }
     }
   }
 }
 ```
 
-### Cursor / VS Code
+#### Cursor / Windsurf
 
-In your MCP client settings, add:
+Add to your MCP config (`.cursor/mcp.json` or `.windsurf/mcp.json`):
 
-- **Type**: `streamable-http`
-- **URL**: `https://luma.mcp.acedata.cloud/mcp`
-- **Headers**: `Authorization: Bearer your_api_token_here`
+```json
+{
+  "mcpServers": {
+    "luma": {
+      "type": "streamable-http",
+      "url": "https://luma.mcp.acedata.cloud/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_TOKEN"
+      }
+    }
+  }
+}
+```
 
-### JetBrains IDEs
+#### VS Code (Copilot)
 
-Install the [Luma MCP plugin](https://plugins.jetbrains.com/plugin/com.acedatacloud.mcp.luma) from the JetBrains Marketplace, or configure manually:
+Add to your VS Code MCP config (`.vscode/mcp.json`):
+
+```json
+{
+  "servers": {
+    "luma": {
+      "type": "streamable-http",
+      "url": "https://luma.mcp.acedata.cloud/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 11 MCP servers with one-click setup.
+
+#### JetBrains IDEs
 
 1. Go to **Settings → Tools → AI Assistant → Model Context Protocol (MCP)**
-2. Click **Add** and select **HTTP**
-3. Paste this configuration:
+2. Click **Add** → **HTTP**
+3. Paste:
 
 ```json
 {
@@ -148,35 +107,71 @@ Install the [Luma MCP plugin](https://plugins.jetbrains.com/plugin/com.acedatacl
     "luma": {
       "url": "https://luma.mcp.acedata.cloud/mcp",
       "headers": {
-        "Authorization": "Bearer your_api_token_here"
+        "Authorization": "Bearer YOUR_API_TOKEN"
       }
     }
   }
 }
 ```
 
-### cURL Test
+#### cURL Test
 
 ```bash
 # Health check (no auth required)
 curl https://luma.mcp.acedata.cloud/health
 
-# MCP initialize (requires Bearer token)
+# MCP initialize
 curl -X POST https://luma.mcp.acedata.cloud/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
-  -H "Authorization: Bearer your_api_token_here" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 ```
 
-### Self-Hosting with Docker
+### 3. Or Run Locally (Alternative)
+
+If you prefer to run the server on your own machine:
+
+```bash
+# Install from PyPI
+pip install mcp-luma
+# or
+uvx mcp-luma
+
+# Set your API token
+export ACEDATACLOUD_API_TOKEN="your_token_here"
+
+# Run (stdio mode for Claude Desktop / local clients)
+mcp-luma
+
+# Run (HTTP mode for remote access)
+mcp-luma --transport http --port 8000
+```
+
+#### Claude Desktop (Local)
+
+```json
+{
+  "mcpServers": {
+    "luma": {
+      "command": "uvx",
+      "args": ["mcp-luma"],
+      "env": {
+        "ACEDATACLOUD_API_TOKEN": "your_token_here"
+      }
+    }
+  }
+}
+```
+
+#### Docker (Self-Hosting)
 
 ```bash
 docker pull ghcr.io/acedatacloud/mcp-luma:latest
 docker run -p 8000:8000 ghcr.io/acedatacloud/mcp-luma:latest
 ```
 
-Clients connect with their own Bearer token — the server extracts the token from each request's `Authorization` header and uses it for upstream API calls.
+Clients connect with their own Bearer token — the server extracts the token from each request's `Authorization` header.
 
 ## Available Tools
 

--- a/server.json
+++ b/server.json
@@ -26,5 +26,11 @@
       ]
     }
   ],
-  "websiteUrl": "https://platform.acedata.cloud"
+  "websiteUrl": "https://platform.acedata.cloud",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://luma.mcp.acedata.cloud/mcp"
+    }
+  ]
 }


### PR DESCRIPTION
## Changes

Restructures the README to **prioritize the hosted/cloud MCP server** as the recommended usage method, making it easier for users to get started without local installation.

### What changed

- **Quick Start**: Now leads with cloud-hosted endpoint (recommended) — no local install needed
- **API Token**: Clear step-by-step instructions with direct links to the platform
- **Client Configs**: Added ready-to-paste configs for Claude Desktop, Cursor, Windsurf, VS Code, and JetBrains IDEs
- **Local Install**: Moved to Alternative section for users who prefer self-hosting
- **server.json**: Added  field for MCP Registry hosted endpoint discovery

### Why

Users should be able to start using the MCP server in seconds by just adding the hosted URL and their API token — no Python, no pip, no dependencies needed. The hosted servers are already deployed and maintained by AceDataCloud.
