### PR TITLE
fix: JetBrains version format and profile update token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -313,10 +313,11 @@ jobs:
       - name: Generate version
         id: jb_version
         run: |
-          # Use CalVer: YYYY.M.BUILD
+          # Use CalVer: YYYY.M.D.BUILD (match PyPI format)
           YEAR=$(date +'%Y')
           MONTH=$(date +'%-m')
-          VERSION_PREFIX="${YEAR}.${MONTH}"
+          DAY=$(date +'%-d')
+          VERSION_PREFIX="${YEAR}.${MONTH}.${DAY}"
           # Query JetBrains Marketplace for latest version today
           BUILD=$(python3 -c "
           import urllib.request, json

--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Dispatch update-profile to Index repo
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.VSCODE_MCP_DISPATCH_TOKEN }}
           repository: AceDataCloud/Index
           event-type: update-profile


### PR DESCRIPTION
**Two CI/CD fixes:**

1. **JetBrains Plugin version**: Changed from `YYYY.M.BUILD` to `YYYY.M.D.BUILD` format to match PyPI CalVer. The old format caused version conflicts when publishing on different days within the same month (e.g., `2026.3.0` already exists).

2. **Profile Update token**: Changed from `secrets.BOT_TOKEN` (never set) to `secrets.VSCODE_MCP_DISPATCH_TOKEN` (already configured). This fixes the 'Parameter token or opts.auth is required' error.